### PR TITLE
Update-turbo-and-timespan-input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "dependencies": {
         "@changesets/cli": "^2.26.2",
-        "turbo": "^1.11.3"
+        "turbo": "^2.3.3"
       }
     },
     "apps/docs": {
@@ -2553,6 +2553,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
       "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+      "license": "MIT"
+    },
+    "node_modules/@date-fns/utc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.0.tgz",
+      "integrity": "sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA==",
       "license": "MIT"
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -8706,9 +8712,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "funding": [
         {
           "type": "opencollective",
@@ -8722,7 +8728,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capitalize": {
       "version": "2.0.4",
@@ -23469,88 +23476,95 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.11.3.tgz",
-      "integrity": "sha512-RCJOUFcFMQNIGKSjC9YmA5yVP1qtDiBA0Lv9VIgrXraI5Da1liVvl3VJPsoDNIR9eFMyA/aagx1iyj6UWem5hA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.3.3.tgz",
+      "integrity": "sha512-DUHWQAcC8BTiUZDRzAYGvpSpGLiaOQPfYXlCieQbwUvmml/LRGIe3raKdrOPOoiX0DYlzxs2nH6BoWJoZrj8hA==",
+      "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.11.3",
-        "turbo-darwin-arm64": "1.11.3",
-        "turbo-linux-64": "1.11.3",
-        "turbo-linux-arm64": "1.11.3",
-        "turbo-windows-64": "1.11.3",
-        "turbo-windows-arm64": "1.11.3"
+        "turbo-darwin-64": "2.3.3",
+        "turbo-darwin-arm64": "2.3.3",
+        "turbo-linux-64": "2.3.3",
+        "turbo-linux-arm64": "2.3.3",
+        "turbo-windows-64": "2.3.3",
+        "turbo-windows-arm64": "2.3.3"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.11.3.tgz",
-      "integrity": "sha512-IsOOg2bVbIt3o/X8Ew9fbQp5t1hTHN3fGNQYrPQwMR2W1kIAC6RfbVD4A9OeibPGyEPUpwOH79hZ9ydFH5kifw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.3.3.tgz",
+      "integrity": "sha512-bxX82xe6du/3rPmm4aCC5RdEilIN99VUld4HkFQuw+mvFg6darNBuQxyWSHZTtc25XgYjQrjsV05888w1grpaA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.11.3.tgz",
-      "integrity": "sha512-FsJL7k0SaPbJzI/KCnrf/fi3PgCDCjTliMc/kEFkuWVA6Httc3Q4lxyLIIinz69q6JTx8wzh6yznUMzJRI3+dg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.3.3.tgz",
+      "integrity": "sha512-DYbQwa3NsAuWkCUYVzfOUBbSUBVQzH5HWUFy2Kgi3fGjIWVZOFk86ss+xsWu//rlEAfYwEmopigsPYSmW4X15A==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.11.3.tgz",
-      "integrity": "sha512-SvW7pvTVRGsqtSkII5w+wriZXvxqkluw5FO/MNAdFw0qmoov+PZ237+37/NgArqE3zVn1GX9P6nUx9VO+xcQAg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.3.3.tgz",
+      "integrity": "sha512-eHj9OIB0dFaP6BxB88jSuaCLsOQSYWBgmhy2ErCu6D2GG6xW3b6e2UWHl/1Ho9FsTg4uVgo4DB9wGsKa5erjUA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.11.3.tgz",
-      "integrity": "sha512-YhUfBi1deB3m+3M55X458J6B7RsIS7UtM3P1z13cUIhF+pOt65BgnaSnkHLwETidmhRh8Dl3GelaQGrB3RdCDw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.3.3.tgz",
+      "integrity": "sha512-NmDE/NjZoDj1UWBhMtOPmqFLEBKhzGS61KObfrDEbXvU3lekwHeoPvAMfcovzswzch+kN2DrtbNIlz+/rp8OCg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.11.3.tgz",
-      "integrity": "sha512-s+vEnuM2TiZuAUUUpmBHDr6vnNbJgj+5JYfnYmVklYs16kXh+EppafYQOAkcRIMAh7GjV3pLq5/uGqc7seZeHA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.3.3.tgz",
+      "integrity": "sha512-O2+BS4QqjK3dOERscXqv7N2GXNcqHr9hXumkMxDj/oGx9oCatIwnnwx34UmzodloSnJpgSqjl8iRWiY65SmYoQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.11.3.tgz",
-      "integrity": "sha512-ZR5z5Zpc7cASwfdRAV5yNScCZBsgGSbcwiA/u3farCacbPiXsfoWUkz28iyrx21/TRW0bi6dbsB2v17swa8bjw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.3.3.tgz",
+      "integrity": "sha512-dW4ZK1r6XLPNYLIKjC4o87HxYidtRRcBeo/hZ9Wng2XM/MqqYkAyzJXJGgRMsc0MMEN9z4+ZIfnSNBrA0b08ag==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -25641,6 +25655,7 @@
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "1.2.0",
+        "@date-fns/utc": "^2.1.0",
         "@sanity/incompatible-plugin": "^1.0.4",
         "@sanity/ui": "^1.8.2",
         "@types/styled-components": "^5.1.28",
@@ -27503,6 +27518,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
       "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg=="
+    },
+    "@date-fns/utc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.0.tgz",
+      "integrity": "sha512-176grgAgU2U303rD2/vcOmNg0kGPbhzckuH1TEP2al7n0AQipZIy9P15usd2TKQCG1g+E1jX/ZVQSzs4sUDwgA=="
     },
     "@dnd-kit/accessibility": {
       "version": "3.0.1",
@@ -30302,6 +30322,7 @@
       "version": "file:packages/sanity-plugin-timespan-input",
       "requires": {
         "@date-fns/tz": "1.2.0",
+        "@date-fns/utc": "^2.1.0",
         "@sanity/incompatible-plugin": "^1.0.4",
         "@sanity/pkg-utils": "^2.4.10",
         "@sanity/plugin-kit": "^3.1.10",
@@ -31937,9 +31958,9 @@
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg=="
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w=="
     },
     "capitalize": {
       "version": "2.0.4",
@@ -42785,52 +42806,52 @@
       }
     },
     "turbo": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.11.3.tgz",
-      "integrity": "sha512-RCJOUFcFMQNIGKSjC9YmA5yVP1qtDiBA0Lv9VIgrXraI5Da1liVvl3VJPsoDNIR9eFMyA/aagx1iyj6UWem5hA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.3.3.tgz",
+      "integrity": "sha512-DUHWQAcC8BTiUZDRzAYGvpSpGLiaOQPfYXlCieQbwUvmml/LRGIe3raKdrOPOoiX0DYlzxs2nH6BoWJoZrj8hA==",
       "requires": {
-        "turbo-darwin-64": "1.11.3",
-        "turbo-darwin-arm64": "1.11.3",
-        "turbo-linux-64": "1.11.3",
-        "turbo-linux-arm64": "1.11.3",
-        "turbo-windows-64": "1.11.3",
-        "turbo-windows-arm64": "1.11.3"
+        "turbo-darwin-64": "2.3.3",
+        "turbo-darwin-arm64": "2.3.3",
+        "turbo-linux-64": "2.3.3",
+        "turbo-linux-arm64": "2.3.3",
+        "turbo-windows-64": "2.3.3",
+        "turbo-windows-arm64": "2.3.3"
       }
     },
     "turbo-darwin-64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.11.3.tgz",
-      "integrity": "sha512-IsOOg2bVbIt3o/X8Ew9fbQp5t1hTHN3fGNQYrPQwMR2W1kIAC6RfbVD4A9OeibPGyEPUpwOH79hZ9ydFH5kifw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.3.3.tgz",
+      "integrity": "sha512-bxX82xe6du/3rPmm4aCC5RdEilIN99VUld4HkFQuw+mvFg6darNBuQxyWSHZTtc25XgYjQrjsV05888w1grpaA==",
       "optional": true
     },
     "turbo-darwin-arm64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.11.3.tgz",
-      "integrity": "sha512-FsJL7k0SaPbJzI/KCnrf/fi3PgCDCjTliMc/kEFkuWVA6Httc3Q4lxyLIIinz69q6JTx8wzh6yznUMzJRI3+dg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.3.3.tgz",
+      "integrity": "sha512-DYbQwa3NsAuWkCUYVzfOUBbSUBVQzH5HWUFy2Kgi3fGjIWVZOFk86ss+xsWu//rlEAfYwEmopigsPYSmW4X15A==",
       "optional": true
     },
     "turbo-linux-64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.11.3.tgz",
-      "integrity": "sha512-SvW7pvTVRGsqtSkII5w+wriZXvxqkluw5FO/MNAdFw0qmoov+PZ237+37/NgArqE3zVn1GX9P6nUx9VO+xcQAg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.3.3.tgz",
+      "integrity": "sha512-eHj9OIB0dFaP6BxB88jSuaCLsOQSYWBgmhy2ErCu6D2GG6xW3b6e2UWHl/1Ho9FsTg4uVgo4DB9wGsKa5erjUA==",
       "optional": true
     },
     "turbo-linux-arm64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.11.3.tgz",
-      "integrity": "sha512-YhUfBi1deB3m+3M55X458J6B7RsIS7UtM3P1z13cUIhF+pOt65BgnaSnkHLwETidmhRh8Dl3GelaQGrB3RdCDw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.3.3.tgz",
+      "integrity": "sha512-NmDE/NjZoDj1UWBhMtOPmqFLEBKhzGS61KObfrDEbXvU3lekwHeoPvAMfcovzswzch+kN2DrtbNIlz+/rp8OCg==",
       "optional": true
     },
     "turbo-windows-64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.11.3.tgz",
-      "integrity": "sha512-s+vEnuM2TiZuAUUUpmBHDr6vnNbJgj+5JYfnYmVklYs16kXh+EppafYQOAkcRIMAh7GjV3pLq5/uGqc7seZeHA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.3.3.tgz",
+      "integrity": "sha512-O2+BS4QqjK3dOERscXqv7N2GXNcqHr9hXumkMxDj/oGx9oCatIwnnwx34UmzodloSnJpgSqjl8iRWiY65SmYoQ==",
       "optional": true
     },
     "turbo-windows-arm64": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.11.3.tgz",
-      "integrity": "sha512-ZR5z5Zpc7cASwfdRAV5yNScCZBsgGSbcwiA/u3farCacbPiXsfoWUkz28iyrx21/TRW0bi6dbsB2v17swa8bjw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.3.3.tgz",
+      "integrity": "sha512-dW4ZK1r6XLPNYLIKjC4o87HxYidtRRcBeo/hZ9Wng2XM/MqqYkAyzJXJGgRMsc0MMEN9z4+ZIfnSNBrA0b08ag==",
       "optional": true
     },
     "type-check": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2549,6 +2549,12 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@date-fns/tz": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+      "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+      "license": "MIT"
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
@@ -10354,14 +10360,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
-      "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
-      "peerDependencies": {
-        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/date-now": {
@@ -25639,14 +25637,14 @@
     },
     "packages/sanity-plugin-timespan-input": {
       "name": "@seidhr/sanity-plugin-timespan-input",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
+        "@date-fns/tz": "1.2.0",
         "@sanity/incompatible-plugin": "^1.0.4",
         "@sanity/ui": "^1.8.2",
         "@types/styled-components": "^5.1.28",
-        "date-fns": "^3.2.0",
-        "date-fns-tz": "^1.2.2",
+        "date-fns": "4.1.0",
         "edtf": "^4.5.1"
       },
       "devDependencies": {
@@ -25682,9 +25680,10 @@
       }
     },
     "packages/sanity-plugin-timespan-input/node_modules/date-fns": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
-      "integrity": "sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -27499,6 +27498,11 @@
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
+    },
+    "@date-fns/tz": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+      "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg=="
     },
     "@dnd-kit/accessibility": {
       "version": "3.0.1",
@@ -30297,6 +30301,7 @@
     "@seidhr/sanity-plugin-timespan-input": {
       "version": "file:packages/sanity-plugin-timespan-input",
       "requires": {
+        "@date-fns/tz": "1.2.0",
         "@sanity/incompatible-plugin": "^1.0.4",
         "@sanity/pkg-utils": "^2.4.10",
         "@sanity/plugin-kit": "^3.1.10",
@@ -30305,8 +30310,7 @@
         "@types/styled-components": "^5.1.28",
         "@typescript-eslint/eslint-plugin": "^6.7.0",
         "@typescript-eslint/parser": "^6.7.0",
-        "date-fns": "^3.2.0",
-        "date-fns-tz": "^1.2.2",
+        "date-fns": "4.1.0",
         "edtf": "^4.5.1",
         "eslint": "^8.49.0",
         "eslint-config-prettier": "^9.0.0",
@@ -30327,9 +30331,9 @@
       },
       "dependencies": {
         "date-fns": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.2.0.tgz",
-          "integrity": "sha512-E4KWKavANzeuusPi0jUjpuI22SURAznGkx7eZV+4i6x2A+IZxAMcajgkvuDAU1bg40+xuhW1zRdVIIM/4khuIg=="
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+          "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
         }
       }
     },
@@ -33173,12 +33177,6 @@
       "requires": {
         "@babel/runtime": "^7.21.0"
       }
-    },
-    "date-fns-tz": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
-      "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
-      "requires": {}
     },
     "date-now": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.26.2",
-    "turbo": "^1.11.3"
-  }
+    "turbo": "^2.3.3"
+  },
+  "packageManager": "npm@10.8.2"
 }

--- a/packages/sanity-plugin-muna-schemas/package.json
+++ b/packages/sanity-plugin-muna-schemas/package.json
@@ -21,15 +21,14 @@
   "author": "Tarje Sælen Lavik <tarje.lavik@gmail.com>",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
       "import": "./dist/index.esm.js",
-      "require": "./dist/index.js",
-      "default": "./dist/index.esm.js"
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",

--- a/packages/sanity-plugin-timespan-input/package.json
+++ b/packages/sanity-plugin-timespan-input/package.json
@@ -53,8 +53,8 @@
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/ui": "^1.8.2",
     "@types/styled-components": "^5.1.28",
-    "date-fns": "^3.2.0",
-    "date-fns-tz": "^1.2.2",
+    "date-fns": "4.1.0",
+    "@date-fns/tz": "1.2.0",
     "edtf": "^4.5.1"
   },
   "devDependencies": {

--- a/packages/sanity-plugin-timespan-input/package.json
+++ b/packages/sanity-plugin-timespan-input/package.json
@@ -50,11 +50,12 @@
     "link-watch": "plugin-kit link-watch"
   },
   "dependencies": {
+    "@date-fns/tz": "1.2.0",
+    "@date-fns/utc": "^2.1.0",
     "@sanity/incompatible-plugin": "^1.0.4",
     "@sanity/ui": "^1.8.2",
     "@types/styled-components": "^5.1.28",
     "date-fns": "4.1.0",
-    "@date-fns/tz": "1.2.0",
     "edtf": "^4.5.1"
   },
   "devDependencies": {

--- a/packages/sanity-plugin-timespan-input/src/components/index.tsx
+++ b/packages/sanity-plugin-timespan-input/src/components/index.tsx
@@ -5,6 +5,7 @@ import { Period } from './period'
 
 export function Preview({ value }: any): ReactNode {
   const { beginOfTheBegin, endOfTheBegin, beginOfTheEnd, endOfTheEnd, date } = value
+
   return (
     <>
       {beginOfTheBegin || endOfTheBegin || beginOfTheEnd || endOfTheEnd || date ? (

--- a/packages/sanity-plugin-timespan-input/src/components/period.tsx
+++ b/packages/sanity-plugin-timespan-input/src/components/period.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/require-default-props */
 // eslint-disable-next-line no-unused-vars
 import React, { CSSProperties, ReactNode } from 'react'
-import { Box, Flex, Stack } from '@sanity/ui'
+import { Box, Flex, Stack, useTheme } from '@sanity/ui'
 import { ArrowLeftIcon, ArrowRightIcon } from '@sanity/icons'
 import { format } from 'date-fns'
 
@@ -16,43 +16,90 @@ export const Period = ({
   end?: string
   variant?: 'fuzzy' | 'certain' | 'unknown' | 'infinity'
 }): ReactNode => {
-  let bg: CSSProperties | undefined
+  let bg: { light: CSSProperties; dark: CSSProperties } | undefined
+
+  const theme = useTheme()
+
+  const mode = theme.sanity.color.dark ? 'dark' : 'light'
 
   switch (variant) {
     case 'fuzzy':
       bg = {
-        backgroundImage:
-          'repeating-linear-gradient(45deg, #000000 0, #000000 0.5px, transparent 0, transparent 50%)',
-        backgroundSize: '5px 5px',
-        backgroundColor: '#ffffff',
-        borderBlockStart: '1px solid #444',
-        borderBlockEnd: '1px solid #444',
+        light: {
+          backgroundImage:
+            'repeating-linear-gradient(45deg, #000000 0, #000000 0.5px, transparent 0, transparent 50%)',
+          backgroundSize: '5px 5px',
+          backgroundColor: '#ffffff',
+          borderBlockStart: '1px solid #444',
+          borderBlockEnd: '1px solid #444',
+          color: '#000000',
+        },
+        dark: {
+          backgroundImage:
+            'repeating-linear-gradient(45deg, #dddddd 0, #dddddd 0.5px, transparent 0, transparent 50%)',
+          backgroundSize: '5px 5px',
+          backgroundColor: '#000000',
+          borderBlockStart: '1px solid #ccc',
+          borderBlockEnd: '1px solid #ccc',
+          color: '#000000',
+        },
       }
       break
     case 'certain':
       bg = {
-        backgroundImage:
-          'repeating-linear-gradient(45deg, #000000 0, #000000 0.5px, transparent 0, transparent 50%), repeating-linear-gradient(-45deg, #000000 0, #000000 0.5px, transparent 0, transparent 50%)',
-        backgroundSize: '5px 5px',
-        backgroundColor: '#ffffff',
-        borderBlockStart: '1px solid #444',
-        borderBlockEnd: '1px solid #444',
+        light: {
+          backgroundImage:
+            'repeating-linear-gradient(45deg, #000000 0, #000000 0.5px, transparent 0, transparent 50%), repeating-linear-gradient(-45deg, #000000 0, #000000 0.5px, transparent 0, transparent 50%)',
+          backgroundSize: '5px 5px',
+          backgroundColor: '#ffffff',
+          borderBlockStart: '1px solid #444',
+          borderBlockEnd: '1px solid #444',
+          color: '#000000',
+        },
+        dark: {
+          backgroundImage:
+            'repeating-linear-gradient(45deg, #dddddd 0, #dddddd 0.5px, transparent 0, transparent 50%), repeating-linear-gradient(-45deg, #000000 0, #000000 0.5px, transparent 0, transparent 50%)',
+          backgroundSize: '5px 5px',
+          backgroundColor: '#000000',
+          borderBlockStart: '1px solid #ccc',
+          borderBlockEnd: '1px solid #ccc',
+          color: '#000000',
+        },
       }
       break
     case 'unknown':
       bg = {
-        borderBlockStart: '1px solid #444',
-        borderBlockEnd: '1px solid #444',
+        light: {
+          borderBlockStart: '1px solid #444',
+          borderBlockEnd: '1px solid #444',
+          color: '#000000',
+        },
+        dark: {
+          borderBlockStart: '1px solid #ccc',
+          borderBlockEnd: '1px solid #ccc',
+          color: '#000000',
+        },
       }
       break
     case 'infinity':
       bg = {
-        borderBlockStart: '1px solid #444',
-        borderBlockEnd: '1px solid #444',
+        light: {
+          borderBlockStart: '1px solid #444',
+          borderBlockEnd: '1px solid #444',
+          color: '#000000',
+        },
+        dark: {
+          borderBlockStart: '1px solid #ccc',
+          borderBlockEnd: '1px solid #ccc',
+          color: '#000000',
+        },
       }
       break
     default:
-      bg = {}
+      bg = {
+        light: {},
+        dark: {},
+      }
       break
   }
 
@@ -84,7 +131,7 @@ export const Period = ({
           </>
         )}
       </Box>
-      <Flex flex={1} justify={'center'} paddingY={1} style={bg}>
+      <Flex flex={1} justify={'center'} paddingY={1} style={bg[mode]}>
         <Box padding={1} style={{ backgroundColor: 'white', borderRadius: '5px' }}>
           {name}
         </Box>

--- a/packages/sanity-plugin-timespan-input/src/mapEDTF.ts
+++ b/packages/sanity-plugin-timespan-input/src/mapEDTF.ts
@@ -1,21 +1,18 @@
 /* eslint-disable prettier/prettier */
-import { utcToZonedTime, format } from 'date-fns-tz'
-import { fromUnixTime } from 'date-fns'
+import { TZDate } from '@date-fns/tz'
+import { format, fromUnixTime } from 'date-fns'
 import { EDTF, Patch } from './types'
 
 const getDateFromDateTime = (unix: number) => {
   const date = format(
-    utcToZonedTime(fromUnixTime(unix / 1000), 'UTC'),
-    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-    { timeZone: 'UTC' },
+    new TZDate(fromUnixTime(unix / 1000), 'UTC'),
+    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
   )
   return date
 }
 
 const getDateFromDate = (unix: number) => {
-  const date = format(fromUnixTime(unix / 1000), "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", {
-    timeZone: 'UTC',
-  })
+  const date = format(fromUnixTime(unix / 1000), "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
   return date
 }
 

--- a/packages/sanity-plugin-timespan-input/src/schemas/Timespan.tsx
+++ b/packages/sanity-plugin-timespan-input/src/schemas/Timespan.tsx
@@ -3,7 +3,7 @@ import { TimespanInput } from '../TimespanInput'
 import edtf from 'edtf'
 import { StyledDescription } from './styles'
 
-const timespanTypeName = 'Timespan' as const
+const timespanTypeName = 'Timespan'
 
 /* *
  * @public
@@ -38,9 +38,8 @@ export const timespan = defineType({
               Extended Date/Time Format (EDTF) is a way to write dates and times in a way that can
               express{' '}
               <a href="https://www.loc.gov/standards/datetime/background.html">
-                uncertainty and approximations
+                uncertainty and approximations.
               </a>
-              .
             </div>
             <div>
               <ul>

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
       "dependsOn": [
         "^build"


### PR DESCRIPTION
- Upgraded "turbo" dependency from version 1.11.3 to 2.3.3 in package.json and package-lock.json for improved performance.
- Added "@date-fns/utc" version 2.1.0 to the sanity-plugin-timespan-input package.
- Refactored turbo.json to use "tasks" instead of "pipeline" for better clarity.
- Made minor adjustments in Timespan schema and component files for consistency and improved styling.
- Updated caniuse-lite version to 1.0.30001690 for better compatibility.